### PR TITLE
Update url to use cloudfront

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -9,7 +9,7 @@ ETH_OWNER_WALLET=0xe886a1858d2d368ef8f02c65bdd470396a1ab188
 
 PUBLIC_URL=https://audius.co
 
-PROTOCOL_DASHBOARD_BUILD_URL=https://dashboard.audius.org/build.zip
+PROTOCOL_DASHBOARD_BUILD_URL=https://d2wytf24n0i6o4.cloudfront.net/build.zip
 IPFS_PROTOCOL=http
 IPFS_HOST=ipfs
 IPFS_PORT=5001

--- a/.env.stage
+++ b/.env.stage
@@ -8,7 +8,7 @@ ETH_PROVIDER_URL=https://eth-ropsten.alchemyapi.io/v2/SV4pXvCkEEfmp5HU7K1m2qkR-n
 ETH_OWNER_WALLET=0xcccc7428648c4AdC0ae262D3547584dDAE25c465
 
 PUBLIC_URL=https://staging.audius.co
-PROTOCOL_DASHBOARD_BUILD_URL=https://dashboard.staging.audius.org/build.zip
+PROTOCOL_DASHBOARD_BUILD_URL=https://d12y891c1d17lv.cloudfront.net/build.zip
 IPFS_PROTOCOL=http
 IPFS_HOST=ipfs
 IPFS_PORT=5001


### PR DESCRIPTION
Uses the cloudfront url because the domain will now point to IPFS. 