### PR TITLE
Support api. subdomain in nginx

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,5 +1,6 @@
 APP_URL=https://d13trd44psa7h3.cloudfront.net
 BEDTIME_URL=https://di2033imt2ldz.cloudfront.net/
+API_SUBDOMAIN=api.audius.co
 ACCESS_TOKEN=lollapalooza
 
 TOKEN_ADDRESS=0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998

--- a/.env.stage
+++ b/.env.stage
@@ -1,5 +1,6 @@
 APP_URL=https://d25u0ddsuxj633.cloudfront.net
 BEDTIME_URL=https://di2033imt2ldz.cloudfront.net/
+API_SUBDOMAIN=api.staging.audius.co
 ACCESS_TOKEN=outsidelands
 
 TOKEN_ADDRESS=0x74f24429ec3708fc21381e017194A5711E93B751

--- a/nginx/nginx.sh
+++ b/nginx/nginx.sh
@@ -1,4 +1,4 @@
 export CRAWLERS=`tr '\n' '|' < /home/nginx/crawlers.txt` &&
 echo "$CRAWLERS" &&
-envsubst '$$APP_URL $$ACCESS_TOKEN $$CRAWLERS $$BEDTIME_URL' < /home/nginx/nginx.template > /etc/nginx/nginx.conf &&
+envsubst '$$APP_URL $$API_SUBDOMAIN $$ACCESS_TOKEN $$CRAWLERS $$BEDTIME_URL' < /home/nginx/nginx.template > /etc/nginx/nginx.conf &&
 exec nginx -g 'daemon off;'

--- a/nginx/nginx.template
+++ b/nginx/nginx.template
@@ -16,8 +16,15 @@ http {
   proxy_pass_header Authorization;
 
   server {
-    listen 80;
-    listen [::]:80;
+    server_name ${API_SUBDOMAIN};
+    location / {
+      proxy_pass http://127.0.0.1/api;
+    }
+  }
+
+  server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
 
     root /var/www/html;
     index index.html index.htm index.nginx-debian.html;

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,14 @@ router.get([
   }
 )
 
+router.get('/trending/playlists', (
+  req: express.Request,
+  res: express.Response) => {
+    req.params.type = 'trending-playlists'
+    getMetaTagsResponse(MetaTagFormat.Explore, req, res)
+  }
+)
+
 router.get('/error', (
   req: express.Request,
   res: express.Response) => {

--- a/src/servlets/utils/constants.ts
+++ b/src/servlets/utils/constants.ts
@@ -9,7 +9,7 @@ export const MOST_LOVED_URL = 'https://download.audius.co/static-resources/most-
 export const FEELING_LUCKY_URL = 'https://download.audius.co/static-resources/feeling-lucky.png'
 export const USER_NODE_IPFS_GATEWAY = 'https://usermetadata.audius.co/ipfs/'
 
-export type ExploreInfoType = {
+export interface ExploreInfoType {
   title: string,
   description: string,
   image: string
@@ -44,6 +44,11 @@ export const exploreMap: { [key: string]: ExploreInfoType } = {
   'top-playlists': {
     title: 'Top Playlists',
     description: 'The top playlists on Audius right now',
+    image: TOP_PLAYLISTS_URL
+  },
+  'trending-playlists': {
+    title: 'Trending Playlists',
+    description: 'The trending playlists on Audius right now',
     image: TOP_PLAYLISTS_URL
   },
   'most-loved': {


### PR DESCRIPTION
Allows us to more gracefully redirect api.audius.co to the GA box and then use cloudflare's caching. This endpoint is getting smashed on prod rn.