### PR TITLE
Support hash id in api endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       dockerfile: Dockerfile
     container_name: node
     restart: unless-stopped
+    volumes:
+      # Mount the code for hot reloading
+      - .:/usr/src/app
     logging:
       options:
         max-size: 1g

--- a/package-lock.json
+++ b/package-lock.json
@@ -4506,6 +4506,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hashids": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/hashids/-/hashids-2.2.8.tgz",
+      "integrity": "sha512-OI6rsk/OqyX60nBsqxnNl3R7CDv9eMOgxzipshZwXE6cUcBcEyHf8rNDlWVdQJZK3TEynILYybCsNUEQfJsdLA=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ethereumjs-tx": "^2.1.0",
     "express": "^4.17.1",
     "handlebars": "^4.1.2",
+    "hashids": "^2.2.8",
     "https-proxy-agent": "^5.0.0",
     "ipfs-http-client": "^42.0.0",
     "moment": "^2.27.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,18 @@ const router = express.Router()
 
 /** Bedtime Routes */
 
-router.get('/embed/api/tracks/:id', (
+router.get([
+  '/embed/api/tracks/:id',
+  '/embed/api/tracks/hashid/:hashId'], (
   req: express.Request,
   res: express.Response) => {
     getBedtimeResponse(BedtimeFormat.TRACK, req, res)
   }
 )
 
-router.get('/embed/api/collections/:id', (
+router.get([
+  '/embed/api/collections/:id',
+  '/embed/api/collections/hashid/:hashId'], (
   req: express.Request,
   res: express.Response) => {
     getBedtimeResponse(BedtimeFormat.COLLECTION, req, res)

--- a/src/servlets/utils/hashids.ts
+++ b/src/servlets/utils/hashids.ts
@@ -1,0 +1,30 @@
+import Hashids from 'hashids'
+
+const HASH_SALT = 'azowernasdfoia'
+const MIN_LENGTH = 5
+const hashids = new Hashids(HASH_SALT, MIN_LENGTH)
+
+/** Decodes a string id into an int. Returns null if an invalid ID. */
+export const decodeHashId = (id: string): number | null => {
+  try {
+    const ids = hashids.decode(id)
+    if (!ids.length) return null
+    const num = Number(ids[0])
+    if (isNaN(num)) return null
+    return num
+  } catch (e) {
+    console.error(`Failed to decode ${id}`, e)
+    return null
+  }
+}
+
+export const encodeHashId = (id: number | null = null): string | null => {
+  try {
+    if (id === null) return null
+    const encodedId = hashids.encode(id)
+    return encodedId
+  } catch (e) {
+    console.error(`Failed to encode ${id}`, e)
+    return null
+  }
+}

--- a/src/servlets/utils/helpers.ts
+++ b/src/servlets/utils/helpers.ts
@@ -7,7 +7,7 @@ import {
 } from './constants'
 
 export const getTrack = async (id: number): Promise<any> => {
-  const t = await libs.Track.getTracks(1, 0, [id])
+  const t = await libs.Track.getTracks(1, 0, [id], null, null, null, null, /* withUsers */ true)
   if (t && t[0]) return t[0]
   throw new Error(`Failed to get track ${id}`)
 }
@@ -19,7 +19,7 @@ export const getTracks = async (ids: number[]): Promise<any> => {
 }
 
 export const getCollection = async (id: number): Promise<any> => {
-  const c = await libs.Playlist.getPlaylists(1, 0, [id])
+  const c = await libs.Playlist.getPlaylists(1, 0, [id], null, /* withUsers */ true)
   if (c && c[0]) return c[0]
   throw new Error(`Failed to get collection ${id}`)
 }

--- a/src/servlets/utils/helpers.ts
+++ b/src/servlets/utils/helpers.ts
@@ -7,7 +7,16 @@ import {
 } from './constants'
 
 export const getTrack = async (id: number): Promise<any> => {
-  const t = await libs.Track.getTracks(1, 0, [id], null, null, null, null, /* withUsers */ true)
+  const t = await libs.Track.getTracks(
+    /* limit */ 1,
+    /* offset */ 0,
+    /* idsArray */ [id],
+    /* targetUserId */ null,
+    /* sort */ null,
+    /* minBlockNumber */ null,
+    /* filterDeleted */ null,
+    /* withUsers */ true
+  )
   if (t && t[0]) return t[0]
   throw new Error(`Failed to get track ${id}`)
 }
@@ -19,7 +28,13 @@ export const getTracks = async (ids: number[]): Promise<any> => {
 }
 
 export const getCollection = async (id: number): Promise<any> => {
-  const c = await libs.Playlist.getPlaylists(1, 0, [id], null, /* withUsers */ true)
+  const c = await libs.Playlist.getPlaylists(
+    /* limit */ 1,
+    /* offset */ 0,
+    /* idsArray */ [id],
+    /* targetUserId */ null,
+    /* withUsers */ true
+  )
   if (c && c[0]) return c[0]
   throw new Error(`Failed to get collection ${id}`)
 }


### PR DESCRIPTION
Support hash ids in bedtime API endpoints in order to support embed URLs like
audius.co/embed/track/BqN19?flavor=tiny

https://linear.app/audius/issue/AUD-663/support-embed-by-id