### PR TITLE
Remove IDs from track routes

### DIFF
--- a/src/servlets/bedtime/helpers.ts
+++ b/src/servlets/bedtime/helpers.ts
@@ -39,16 +39,6 @@ const encodeUrlName = (name: string): string => {
   return encodeURIComponent(formatUrlName(name))
 }
 
-export const getTrackPath = ({
-  ownerHandle,
-  title,
-  id
-}: {
-  ownerHandle: string,
-  title: string,
-  id: number
-}) => `${encodeUrlName(ownerHandle)}/${encodeUrlName(title)}-${id}`
-
 export const getCollectionPath = ({ ownerHandle, isAlbum, name, id }: {
   ownerHandle: string,
   isAlbum: boolean,

--- a/src/servlets/bedtime/index.ts
+++ b/src/servlets/bedtime/index.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import { decodeHashId } from '../utils/hashids'
 
 import { getCollection, getTrack, getTracks, getUser, getUsers, shouldRedirectTrack } from '../utils/helpers'
-import { getCollectionPath, getCoverArt, getTrackPath } from './helpers'
+import { getCollectionPath, getCoverArt } from './helpers'
 import { BedtimeFormat, GetCollectionResponse, GetTracksResponse, TrackResponse } from './types'
 
 // Error Messages
@@ -18,7 +18,6 @@ const getTrackMetadata = async (trackId: number, ownerId: number | null): Promis
 
     const user = track.user
     const coverArt = getCoverArt(track, user)
-    const urlPath = getTrackPath({ ownerHandle: user.handle, title: track.title, id: track.track_id })
 
     return {
       title: track.title,
@@ -27,7 +26,7 @@ const getTrackMetadata = async (trackId: number, ownerId: number | null): Promis
       segments: track.track_segments,
       isVerified: user.is_verified,
       coverArt,
-      urlPath,
+      urlPath: track.permalnk,
       gateways: user.creator_node_endpoint,
       id: track.track_id
     }
@@ -67,7 +66,7 @@ const getTracksFromCollection = async (collection: any, ownerUser: any): Promise
     handle: userMap[t.owner_id].handle,
     userName: userMap[t.owner_id].name,
     segments: t.track_segments,
-    urlPath: getTrackPath({ ownerHandle: userMap[t.owner_id].handle, title: t.title, id: t.track_id }),
+    urlPath: t.permalink,
     id: t.track_id,
     isVerified: userMap[t.owner_id].is_verified,
     gateways: userMap[t.owner_id].creator_node_endpoint

--- a/src/servlets/metaTags/index.ts
+++ b/src/servlets/metaTags/index.ts
@@ -10,10 +10,9 @@ import {
   getCollection,
   getExploreInfo,
   getImageUrl,
-  getTrack,
+  getTrackByHandleAndSlug,
   getUser,
-  getUserByHandle,
-  shouldRedirectTrack
+  getUserByHandle
 } from '../utils/helpers'
 import { Context, MetaTagFormat, Playable } from './types'
 
@@ -33,11 +32,10 @@ const template = handlebars.compile(
     .toString()
 )
 
-const getTrackContext = async (id: number, canEmbed: boolean): Promise<Context> => {
-  if (!id) return getDefaultContext()
-  if (shouldRedirectTrack(id)) return getDefaultContext()
+const getTrackContext = async (handle: string, slug: string, canEmbed: boolean): Promise<Context> => {
+  if (!handle || !slug) return getDefaultContext()
   try {
-    const track = await getTrack(id)
+    const track = await getTrackByHandleAndSlug(handle, slug)
     const user = await getUser(track.owner_id)
     const gateway = formatGateway(user.creator_node_endpoint, user.user_id)
 
@@ -131,10 +129,10 @@ const getUserContext = async (handle: string): Promise<Context> => {
   }
 }
 
-const getRemixesContext = async (id: number): Promise<Context> => {
-  if (!id) return getDefaultContext()
+const getRemixesContext = async (handle: string, slug: string): Promise<Context> => {
+  if (!handle || !slug) return getDefaultContext()
   try {
-    const track = await getTrack(id)
+    const track = await getTrackByHandleAndSlug(handle, slug)
     const user = await getUser(track.owner_id)
     const gateway = formatGateway(user.creator_node_endpoint, user.user_id)
 
@@ -219,8 +217,8 @@ const getResponse = async (
   const id = title ? parseInt(title.split('-').slice(-1)[0], 10) : -1
   switch (format) {
     case MetaTagFormat.Track:
-      console.log('get track', req.path, id, userAgent)
-      context = await getTrackContext(id, canEmbed)
+      console.log('get track', req.path, handle, title, userAgent)
+      context = await getTrackContext(handle, title, canEmbed)
       break
     case MetaTagFormat.Collection:
       console.log('get collection', req.path, id, userAgent)
@@ -231,8 +229,8 @@ const getResponse = async (
       context = await getUserContext(handle)
       break
     case MetaTagFormat.Remixes:
-      console.log('get remixes', req.path, id, userAgent)
-      context = await getRemixesContext(id)
+      console.log('get remixes', req.path, handle, title, userAgent)
+      context = await getRemixesContext(handle, title)
       break
     case MetaTagFormat.Upload:
       console.log('get upload', req.path, userAgent)

--- a/src/servlets/utils/helpers.ts
+++ b/src/servlets/utils/helpers.ts
@@ -21,6 +21,12 @@ export const getTrack = async (id: number): Promise<any> => {
   throw new Error(`Failed to get track ${id}`)
 }
 
+export const getTrackByHandleAndSlug = async (handle: string, slug: string): Promise<any> => {
+  const track = await libs.Track.getTracksByHandleAndSlug(handle, slug)
+  if (track && track.length > 0) return track[0]
+  throw new Error(`Failed to get track ${handle}/${slug}`)
+}
+
 export const getTracks = async (ids: number[]): Promise<any> => {
   const ts =  await libs.Track.getTracks(ids.length, 0, ids)
   if (ts) return ts


### PR DESCRIPTION
**DO NOT MERGE**

Depends on: https://github.com/AudiusProject/audius-protocol/pull/1687

Updates GA to not need track ID to do track and remixes routes.