### PR TITLE
Handle https.get error

### DIFF
--- a/src/servlets/proxy/index.ts
+++ b/src/servlets/proxy/index.ts
@@ -44,6 +44,9 @@ const proxyRequest = async (proxyUrl: string, formattedUrl: string) => {
           reject(new Error(`Request failed with ${res.statusCode}`))
         }
       })
+    }).on('error', (e: Error) => {
+      console.error(`Error at https.get for ${proxyUrl}`)
+      reject(e)
     })
   })
   const duration = Date.now() - start


### PR DESCRIPTION
Seeing this error in the proxy path which is crashing the GA instance

```
{ Error: socket hang up
    at createHangUpError (_http_client.js:323:15)
    at TLSSocket.socketOnEnd (_http_client.js:426:23)
    at TLSSocket.emit (events.js:203:15)
    at TLSSocket.EventEmitter.emit (domain.js:448:20)
    at endReadableNT (_stream_readable.js:1145:12)
    at process._tickCallback (internal/process/next_tick.js:63:19) code: 'ECONNRESET' }
[nodemon] app crashed - waiting for file changes before starting...
```

But we don't see this super consistently, so the repro is a bit hard. I believe it's due to some messed up content length header https://stackoverflow.com/questions/31864707/node-socket-hang-up-error-with-http

This (I believe) can be traced to lack of a .on('error') handler https://nodejs.org/api/https.html#httpsgetoptions-callback


Tested:
Redeployed with this change and it doesn't crash