### PR TITLE
Use request promise for proxy layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -991,6 +991,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
+      "dev": true
+    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -1166,6 +1172,16 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/request-promise": {
+      "version": "4.1.48",
+      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.48.tgz",
+      "integrity": "sha512-sLsfxfwP5G3E3U64QXxKwA6ctsxZ7uKyl4I28pMj3JvV+ztWECRns73GL71KMOOJME5u1A5Vs5dkBqyiR1Zcnw==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/request": "*"
       }
     },
     "@types/secp256k1": {
@@ -1374,29 +1390,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
     },
     "ajv": {
       "version": "6.12.2",
@@ -4435,30 +4428,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "iconv-lite": {
@@ -8017,11 +7986,21 @@
         }
       }
     },
+    "request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "request-promise-core": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.19"
       },
@@ -8029,8 +8008,7 @@
         "lodash": {
           "version": "4.17.21",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -8720,8 +8698,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-to-it": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "express": "^4.17.1",
     "handlebars": "^4.1.2",
     "hashids": "^2.2.8",
-    "https-proxy-agent": "^5.0.0",
     "ipfs-http-client": "43.0.0",
     "moment": "^2.27.0",
     "node-fetch": "^2.6.1",
+    "request-promise": "^4.2.6",
     "unzipper": "^0.10.11"
   },
   "devDependencies": {
@@ -48,6 +48,7 @@
     "@types/node": "^12.7.1",
     "@types/node-fetch": "^2.5.8",
     "@types/request": "^2.48.2",
+    "@types/request-promise": "^4.1.48",
     "@types/unzipper": "^0.10.3",
     "copyfiles": "^2.4.1",
     "env-cmd": "^9.0.3",

--- a/src/servlets/proxy/index.ts
+++ b/src/servlets/proxy/index.ts
@@ -10,6 +10,20 @@ export const router = express.Router()
 const proxyRequest = async (proxyUrl: string, formattedUrl: string) => {
   console.log(`Proxying to ${formattedUrl} via ${proxyUrl}`)
   const start = Date.now()
+
+  /**
+   * Note:
+   * As of writing implementation request-promise (and request) are deprecated
+   * modules.
+   * Axios is a better (more cannonical solution to Audius), but given
+   * experimentation & outlined issues
+   * https://github.com/axios/axios/issues/925
+   * Proxying to https via an http proxy is not working well with axios.
+   * Several workarounds do not appear to be working on the latest versions
+   * of axios & https proxy agent.
+   * request-promise works well, but its usage should be limited to the scope
+   * of this method.
+   */
   const result = await new Promise((resolve, reject) => {
     request({
       url: formattedUrl,

--- a/src/servlets/proxy/index.ts
+++ b/src/servlets/proxy/index.ts
@@ -68,7 +68,7 @@ router.get('/simple', async (
   expressRes: express.Response
 ) => {
   const url = req.query.url as string
-  const res = await new Promise((resolve, reject) => {
+  const result = await new Promise((resolve, reject) => {
     request({
       url,
       headers: {
@@ -81,5 +81,5 @@ router.get('/simple', async (
       (error) => reject(error)
     )
   })
-  expressRes.send(res)
+  expressRes.send(result)
 })


### PR DESCRIPTION
Although `request` and `request-promise` are deprecated, on testing, proxies are far more reliable w/ this change