### PR TITLE
Don't show deactivated tracks in embed player

### DIFF
--- a/src/servlets/bedtime/index.ts
+++ b/src/servlets/bedtime/index.ts
@@ -64,7 +64,7 @@ const getTracksFromCollection = async (collection: any, ownerUser: any): Promise
 
   // fetch users from tracks
   // only fetch unique IDs that aren't the owner user
-  const trackOwnerIds = tracks.map(t => t.owner_id)
+  const trackOwnerIds = tracks.map((t) => t.owner_id)
   const idsToFetch = new Set(trackOwnerIds.filter((userId: number) => userId !== ownerUser.user_id))
   const users = await getUsers(Array.from(idsToFetch))
 
@@ -73,8 +73,8 @@ const getTracksFromCollection = async (collection: any, ownerUser: any): Promise
 
   // Create tracks and filter out deletes
   const parsedTracks: TrackResponse[] =
-    tracks.filter(t => !t.is_delete && !userMap[t.owner_id].is_deactivated)
-      .map(t => ({
+    tracks.filter((t) => !t.is_delete && !userMap[t.owner_id].is_deactivated)
+      .map((t) => ({
         title: t.title,
         handle: userMap[t.owner_id].handle,
         userName: userMap[t.owner_id].name,

--- a/src/servlets/bedtime/index.ts
+++ b/src/servlets/bedtime/index.ts
@@ -58,7 +58,9 @@ const getTracksFromCollection = async (collection: any, ownerUser: any): Promise
     const unorderedTracks = await getTracks(trackIds)
 
     // reorder tracks - discprov returns tracks out of order
-    const unorderedTracksMap = unorderedTracks.reduce((acc: Record<number, TrackModel>, t) => ({ ...acc, [t.track_id]: t }), {})
+    const unorderedTracksMap = unorderedTracks.reduce(
+      (acc: Record<number, TrackModel>, t) => ({ ...acc, [t.track_id]: t }),
+      {})
     tracks = trackIds.map((id: number) => unorderedTracksMap[id])
   }
 

--- a/src/servlets/bedtime/index.ts
+++ b/src/servlets/bedtime/index.ts
@@ -55,10 +55,10 @@ const getTracksFromCollection = async (collection: any, ownerUser: any): Promise
 
   // Fetch tracks if there are IDs
   if (trackIds.length) {
-    const unordredTracks = await getTracks(trackIds)
+    const unorderedTracks = await getTracks(trackIds)
 
     // reorder tracks - discprov returns tracks out of order
-    const unorderedTracksMap = unordredTracks.reduce((acc: any, t) => ({ ...acc, [t.track_id]: t }), {})
+    const unorderedTracksMap = unorderedTracks.reduce((acc: Record<number, TrackModel>, t) => ({ ...acc, [t.track_id]: t }), {})
     tracks = trackIds.map((id: number) => unorderedTracksMap[id])
   }
 

--- a/src/servlets/bedtime/index.ts
+++ b/src/servlets/bedtime/index.ts
@@ -2,6 +2,7 @@ import { Collectible } from '@audius/fetch-nft'
 import express from 'express'
 
 import libs from '../../libs'
+import { TrackModel } from '../../types/Track'
 import { nftClient } from '../utils/fetchNft'
 import { decodeHashId, encodeHashId } from '../utils/hashids'
 import {
@@ -50,20 +51,20 @@ const getTrackMetadata = async (trackId: number, ownerId: number | null): Promis
 const getTracksFromCollection = async (collection: any, ownerUser: any): Promise<TrackResponse[]> => {
 
   const trackIds: number[] = collection.playlist_contents.track_ids.map((t: {time: number, track: number }) => t.track)
-  let tracks = []
+  let tracks: TrackModel[] = []
 
   // Fetch tracks if there are IDs
   if (trackIds.length) {
     const unordredTracks = await getTracks(trackIds)
 
     // reorder tracks - discprov returns tracks out of order
-    const unorderedTracksMap = unordredTracks.reduce((acc: any, t: any) => ({ ...acc, [t.track_id]: t }), {})
+    const unorderedTracksMap = unordredTracks.reduce((acc: any, t) => ({ ...acc, [t.track_id]: t }), {})
     tracks = trackIds.map((id: number) => unorderedTracksMap[id])
   }
 
   // fetch users from tracks
   // only fetch unique IDs that aren't the owner user
-  const trackOwnerIds = tracks.map((t: any) => t.owner_id)
+  const trackOwnerIds = tracks.map(t => t.owner_id)
   const idsToFetch = new Set(trackOwnerIds.filter((userId: number) => userId !== ownerUser.user_id))
   const users = await getUsers(Array.from(idsToFetch))
 
@@ -72,8 +73,8 @@ const getTracksFromCollection = async (collection: any, ownerUser: any): Promise
 
   // Create tracks and filter out deletes
   const parsedTracks: TrackResponse[] =
-    tracks.filter((t: any) => !t.is_delete && !userMap[t.owner_id].is_deactivated)
-      .map((t: any) => ({
+    tracks.filter(t => !t.is_delete && !userMap[t.owner_id].is_deactivated)
+      .map(t => ({
         title: t.title,
         handle: userMap[t.owner_id].handle,
         userName: userMap[t.owner_id].name,

--- a/src/servlets/utils/helpers.ts
+++ b/src/servlets/utils/helpers.ts
@@ -1,5 +1,6 @@
 import libs from '../../libs'
-import { FullTrack, Track, TrackModel } from '../../types/Track'
+import { FullTrack, Track, TrackModel, TrackSegment } from '../../types/Track'
+import { FullUser, UserModel } from '../../types/User'
 import {
   DEFAULT_IMAGE_URL,
   ExploreInfoType,
@@ -29,29 +30,59 @@ export const getTracks = async (ids: number[]): Promise<TrackModel[]> => {
   throw new Error(`Failed to get tracks ${ids}`)
 }
 
-const extendTrack = async (track: TrackModel): Promise<Track & TrackModel> => {
-  const user = await getUser(track.owner_id)
+const userModelToFullUser = (user: UserModel): FullUser => {
+  return {
+    ...user,
+    id: encodeHashId(user.user_id)!,
+    cover_photo_legacy: null,
+    profile_picture_legacy: null
+  }
+}
+
+const trackModelToFullTrack = async (track: TrackModel): Promise<FullTrack> => {
+  const user: UserModel = await getUser(track.owner_id)
   const gateway = formatGateway(user.creator_node_endpoint, user.user_id)
 
   const coverArt = track.cover_art_sizes
     ? `${track.cover_art_sizes}/1000x1000.jpg`
     : track.cover_art
   const artwork = {
+    ['150x150']: null,
+    ['480x480']: null,
     ['1000x1000']: getImageUrl(coverArt, gateway)
   }
 
   const releaseDate = track.release_date ? track.release_date : track.created_at
   const duration = track.track_segments.reduce(
-    (acc: number, v: any) => acc = acc + v.duration,
+    (acc: number, v) => acc = acc + v.duration,
     0
   )
+
+  // Map remix_of and stem_of to FullTrack
+  const remixOf = track.remix_of
+    ? {
+      tracks: track.remix_of.tracks.map((t) => ({
+        ...t,
+        parent_track_id: encodeHashId(t.parent_track_id)!,
+        user: userModelToFullUser(user)
+      }))
+    }
+    : null
+  const stemOf = { category: null, parent_track_id: null }
+
   return {
     ...track,
     id: encodeHashId(track.track_id)!,
-    user,
+    user: userModelToFullUser(user),
     artwork,
     release_date: releaseDate,
-    duration
+    duration,
+    remix_of: remixOf,
+    stem_of: stemOf,
+    favorite_count: track.save_count,
+    downloadable: track.download.is_downloadable,
+    followee_favorites: track.followee_saves,
+    user_id: encodeHashId(track.owner_id)!
   }
 }
 
@@ -59,7 +90,6 @@ export const getTrackByHandleAndSlug = async (handle: string, slug: string): Pro
   const track = await libs.Track.getTracksByHandleAndSlug(handle, slug)
   if (track) return Array.isArray(track) ? track[0] : track
 
-  // Try the old route method, ensuring that the track once found has the same owner handle.
   // Ensure at least 5 digits (anything lower has old route in the DB)
   const matches = slug.match(/[0-9]{5,}$/)
   if (matches) {
@@ -68,7 +98,7 @@ export const getTrackByHandleAndSlug = async (handle: string, slug: string): Pro
       const splitted = tracks[0].permalink.split('/')
       const foundHandle = splitted.length > 0 ? splitted[1] : ''
       if (foundHandle.toLowerCase() === handle.toLowerCase()) {
-        return extendTrack(tracks[0])
+        return trackModelToFullTrack(tracks[0])
       }
     }
   }
@@ -87,19 +117,19 @@ export const getCollection = async (id: number): Promise<any> => {
   throw new Error(`Failed to get collection ${id}`)
 }
 
-export const getUser = async (id: number): Promise<any> => {
+export const getUser = async (id: number): Promise<UserModel> => {
   const u = await libs.User.getUsers(1, 0, [id])
   if (u && u[0]) return u[0]
   throw new Error(`Failed to get user ${id}`)
 }
 
-export const getUsers = async (ids: number[]): Promise<any> => {
+export const getUsers = async (ids: number[]): Promise<UserModel[]> => {
   const us = await libs.User.getUsers(ids.length, 0, ids)
   if (us) return us
   throw new Error(`Failed to get users: ${ids}`)
 }
 
-export const getUserByHandle = async (handle: string): Promise<any> => {
+export const getUserByHandle = async (handle: string): Promise<UserModel> => {
   const u = await libs.User.getUsers(1, 0, null, null, handle)
   if (u && u[0]) return u[0]
   throw new Error(`Failed to get user ${handle}`)
@@ -110,7 +140,7 @@ export const formatGateway = (creatorNodeEndpoint: string, userId: number): stri
     ? `${creatorNodeEndpoint.split(',')[0]}/ipfs/`
     : USER_NODE_IPFS_GATEWAY
 
-export const getImageUrl = (cid: string, gateway: string | null): string => {
+export const getImageUrl = (cid: string | null, gateway: string | null): string => {
   if (!cid) return DEFAULT_IMAGE_URL
   return `${gateway}${cid}`
 }

--- a/src/servlets/utils/helpers.ts
+++ b/src/servlets/utils/helpers.ts
@@ -1,4 +1,5 @@
 import libs from '../../libs'
+import { FullTrack, Track, TrackModel } from '../../types/Track'
 import {
   DEFAULT_IMAGE_URL,
   ExploreInfoType,
@@ -7,7 +8,7 @@ import {
 } from './constants'
 import { encodeHashId } from './hashids'
 
-export const getTrack = async (id: number): Promise<any> => {
+export const getTrack = async (id: number): Promise<TrackModel> => {
   const t = await libs.Track.getTracks(
     /* limit */ 1,
     /* offset */ 0,
@@ -22,13 +23,13 @@ export const getTrack = async (id: number): Promise<any> => {
   throw new Error(`Failed to get track ${id}`)
 }
 
-export const getTracks = async (ids: number[]): Promise<any> => {
+export const getTracks = async (ids: number[]): Promise<TrackModel[]> => {
   const ts =  await libs.Track.getTracks(ids.length, 0, ids)
   if (ts) return ts
   throw new Error(`Failed to get tracks ${ids}`)
 }
 
-const extendTrack = async (track: any): Promise<any> => {
+const extendTrack = async (track: TrackModel): Promise<Track & TrackModel> => {
   const user = await getUser(track.owner_id)
   const gateway = formatGateway(user.creator_node_endpoint, user.user_id)
 
@@ -46,7 +47,7 @@ const extendTrack = async (track: any): Promise<any> => {
   )
   return {
     ...track,
-    id: encodeHashId(track.track_id),
+    id: encodeHashId(track.track_id)!,
     user,
     artwork,
     release_date: releaseDate,
@@ -54,7 +55,7 @@ const extendTrack = async (track: any): Promise<any> => {
   }
 }
 
-export const getTrackByHandleAndSlug = async (handle: string, slug: string): Promise<any> => {
+export const getTrackByHandleAndSlug = async (handle: string, slug: string): Promise<Track> => {
   const track = await libs.Track.getTracksByHandleAndSlug(handle, slug)
   if (track) return Array.isArray(track) ? track[0] : track
 

--- a/src/types/Track.ts
+++ b/src/types/Track.ts
@@ -1,0 +1,140 @@
+import { FullUser, User } from "./User"
+
+export type TrackArtwork = {
+  ["150x150"]?: string
+  ["480x480"]?: string
+  ["1000x1000"]?: string
+}
+
+export type RemixParent = {
+  tracks: Array<{ parent_track_id: number }>
+}
+
+
+export type Track = {
+  artwork: TrackArtwork,
+  description: string
+  genre?: string
+  id: string
+  mood?: string
+  release_date: string
+  remix_of: RemixParent
+  repost_count?: number
+  favorite_count?: number
+  tags?: string
+  title: string
+  user: User
+  duration: number
+  downloadable?: boolean
+  play_count?: number
+  permalink?: string
+}
+
+
+export type TrackDownload = {
+  cid: string
+  is_downloadable: string
+  requires_follow: string
+}
+
+export type TrackFieldVisibility = {
+  mood: boolean
+  tags: boolean
+  genre: boolean
+  share: boolean
+  play_count: boolean
+  remixes: boolean
+}
+
+export type Repost = {
+  repost_item_id: string
+  repost_type: string
+  user_id: string
+}
+
+export type Favorite = {
+  favorite_item_id: string
+  favorite_type: string
+  user_id: string
+}
+
+export type StemParent = {
+  category: string
+  parent_track_id: number
+}
+
+export type TrackSegment = {
+  duration: number
+  multihash: string
+}
+
+export type FullRemixParent = {
+  parent_track_id: string
+  user: FullUser
+  has_remix_author_reposted: boolean
+  has_remix_author_saved: boolean
+}
+
+export type FullTrack = Track & {
+  blocknumber: number
+  create_date: string
+  cover_art_sizes: string
+  created_at: string
+  credits_splits: string
+  download: TrackDownload
+  isrc: string
+  license: string
+  iswc: string
+  field_visibility: TrackFieldVisibility
+  followee_reposts: Repost[]
+  has_current_user_reposted: boolean
+  is_unlisted: boolean
+  has_current_user_saved: boolean
+  followee_favorites: Favorite[]
+  route_id: string
+  stem_of: StemParent[]
+  track_segments: TrackSegment[]
+  updated_at: string
+  user_id: string
+  user: FullUser
+  is_delete: boolean
+  cover_art: string
+  remix_of: FullRemixParent
+}
+
+export type TrackModel = {
+  blockhash: string
+  blocknumber: number
+  txhash: string
+  track_id: number
+  is_current: boolean
+  is_delete: boolean
+  owner_id: number
+  route_id: string
+  title: string
+  length: number
+  cover_art: string
+  cover_art_sizes: string
+  tags: string
+  genre: string
+  mood: string
+  credits_splits: string
+  remix_of: any
+  create_date: string
+  release_date: string
+  file_type: string
+  description: string
+  license: string
+  isrc: string
+  iswc: string
+  track_segments: any
+  metadata_multihash: string
+  download: any
+  updated_at: string
+  created_at: string
+  is_unlisted: boolean
+  field_visibility: TrackFieldVisibility
+  stem_of: any
+  permalink: string
+  user: FullUser
+}

--- a/src/types/Track.ts
+++ b/src/types/Track.ts
@@ -100,6 +100,13 @@ export type FullTrack = Track & {
   remix_of: FullRemixParent
 }
 
+export type RemixParentModel = {
+  has_remix_author_reposted: boolean
+  has_remix_author_saved: boolean
+  parent_track_id: number
+  user: UserModel
+}
+
 export type TrackModel = {
   blockhash: string
   blocknumber: number
@@ -117,7 +124,7 @@ export type TrackModel = {
   genre: string
   mood: string
   credits_splits: string
-  remix_of: any
+  remix_of?: { tracks: RemixParentModel[] }
   create_date: string
   release_date: string
   file_type: string
@@ -125,14 +132,14 @@ export type TrackModel = {
   license: string
   isrc: string
   iswc: string
-  track_segments: any
+  track_segments: TrackSegment[]
   metadata_multihash: string
-  download: any
+  download: TrackDownload
   updated_at: string
   created_at: string
   is_unlisted: boolean
   field_visibility: TrackFieldVisibility
-  stem_of: any
+  stem_of: null
   permalink: string
   user: FullUser
 }

--- a/src/types/Track.ts
+++ b/src/types/Track.ts
@@ -1,15 +1,14 @@
-import { FullUser, User } from "./User"
+import { FullUser, User } from './User'
 
 export type TrackArtwork = {
-  ["150x150"]?: string
-  ["480x480"]?: string
-  ["1000x1000"]?: string
+  ['150x150']?: string
+  ['480x480']?: string
+  ['1000x1000']?: string
 }
 
 export type RemixParent = {
   tracks: Array<{ parent_track_id: number }>
 }
-
 
 export type Track = {
   artwork: TrackArtwork,
@@ -29,7 +28,6 @@ export type Track = {
   play_count?: number
   permalink?: string
 }
-
 
 export type TrackDownload = {
   cid: string

--- a/src/types/Track.ts
+++ b/src/types/Track.ts
@@ -1,47 +1,53 @@
-import { FullUser, User } from './User'
+import { FullUser, User, UserModel } from './User'
+
+/** The general case models come from the "/v1" routes **/
 
 export type TrackArtwork = {
-  ['150x150']?: string
-  ['480x480']?: string
-  ['1000x1000']?: string
+  ['150x150']: string | null
+  ['480x480']: string | null
+  ['1000x1000']: string
+}
+
+export type RemixOf<T> = {
+  tracks: T[]
 }
 
 export type RemixParent = {
-  tracks: Array<{ parent_track_id: number }>
+  parent_track_id: string
 }
 
 export type Track = {
   artwork: TrackArtwork,
   description: string
-  genre?: string
+  downloadable: boolean
+  duration: number
+  favorite_count: number
+  genre: string
   id: string
-  mood?: string
+  mood: string
+  permalink: string
+  play_count: number
   release_date: string
-  remix_of: RemixParent
-  repost_count?: number
-  favorite_count?: number
-  tags?: string
+  remix_of: RemixOf<RemixParent> | null
+  repost_count: number
+  tags: string | null
   title: string
   user: User
-  duration: number
-  downloadable?: boolean
-  play_count?: number
-  permalink?: string
 }
 
 export type TrackDownload = {
-  cid: string
-  is_downloadable: string
-  requires_follow: string
+  cid: string | null
+  is_downloadable: boolean
+  requires_follow: boolean
 }
 
 export type TrackFieldVisibility = {
-  mood: boolean
-  tags: boolean
   genre: boolean
-  share: boolean
+  mood: boolean
   play_count: boolean
   remixes: boolean
+  share: boolean
+  tags: boolean
 }
 
 export type Repost = {
@@ -57,8 +63,8 @@ export type Favorite = {
 }
 
 export type StemParent = {
-  category: string
-  parent_track_id: number
+  category: string | null
+  parent_track_id: number | null
 }
 
 export type TrackSegment = {
@@ -66,39 +72,43 @@ export type TrackSegment = {
   multihash: string
 }
 
+/** Prefixed with "full", these models come from the "v1/full" route **/
+
 export type FullRemixParent = {
-  parent_track_id: string
-  user: FullUser
   has_remix_author_reposted: boolean
   has_remix_author_saved: boolean
+  parent_track_id: string
+  user: FullUser
 }
 
 export type FullTrack = Track & {
   blocknumber: number
-  create_date: string
   cover_art_sizes: string
+  cover_art: string
+  create_date: string
   created_at: string
   credits_splits: string
   download: TrackDownload
-  isrc: string
-  license: string
-  iswc: string
   field_visibility: TrackFieldVisibility
+  followee_favorites: Favorite[]
   followee_reposts: Repost[]
   has_current_user_reposted: boolean
-  is_unlisted: boolean
   has_current_user_saved: boolean
-  followee_favorites: Favorite[]
+  is_delete: boolean
+  is_unlisted: boolean
+  isrc: string
+  iswc: string
+  license: string
+  remix_of: RemixOf<FullRemixParent> | null
   route_id: string
-  stem_of: StemParent[]
+  stem_of: StemParent
   track_segments: TrackSegment[]
   updated_at: string
   user_id: string
   user: FullUser
-  is_delete: boolean
-  cover_art: string
-  remix_of: FullRemixParent
 }
+
+/** Suffixed with "model", these types come from the non-v1 API routes **/
 
 export type RemixParentModel = {
   has_remix_author_reposted: boolean
@@ -110,36 +120,43 @@ export type RemixParentModel = {
 export type TrackModel = {
   blockhash: string
   blocknumber: number
-  txhash: string
-  track_id: number
+  cover_art_sizes: string
+  cover_art: string
+  create_date: string
+  created_at: string
+  credits_splits: string
+  description: string
+  download: TrackDownload
+  field_visibility: TrackFieldVisibility
+  file_type: string
+  followee_reposts: Repost[]
+  followee_saves: Favorite[]
+  has_current_user_reposted: boolean
+  has_current_user_saved: boolean
+  genre: string
   is_current: boolean
   is_delete: boolean
-  owner_id: number
-  route_id: string
-  title: string
-  length: number
-  cover_art: string
-  cover_art_sizes: string
-  tags: string
-  genre: string
-  mood: string
-  credits_splits: string
-  remix_of?: { tracks: RemixParentModel[] }
-  create_date: string
-  release_date: string
-  file_type: string
-  description: string
-  license: string
+  is_unlisted: boolean
   isrc: string
   iswc: string
-  track_segments: TrackSegment[]
+  length: number
+  license: string
   metadata_multihash: string
-  download: TrackDownload
-  updated_at: string
-  created_at: string
-  is_unlisted: boolean
-  field_visibility: TrackFieldVisibility
-  stem_of: null
+  mood: string
+  owner_id: number
   permalink: string
-  user: FullUser
+  play_count: number
+  release_date: string
+  remix_of: RemixOf<RemixParentModel> | null
+  repost_count: number
+  route_id: string
+  save_count: number
+  stem_of: null
+  tags: string | null
+  title: string
+  track_id: number
+  track_segments: TrackSegment[]
+  txhash: string
+  updated_at: string
+  user: UserModel
 }

--- a/src/types/Track.ts
+++ b/src/types/Track.ts
@@ -1,7 +1,6 @@
 import { FullUser, User, UserModel } from './User'
 
-/** The general case models come from the "/v1" routes **/
-
+// The general case models come from the "/v1" routes
 export type TrackArtwork = {
   ['150x150']: string | null
   ['480x480']: string | null
@@ -72,8 +71,7 @@ export type TrackSegment = {
   multihash: string
 }
 
-/** Prefixed with "full", these models come from the "v1/full" route **/
-
+// Prefixed with "full", these models come from the "v1/full" route
 export type FullRemixParent = {
   has_remix_author_reposted: boolean
   has_remix_author_saved: boolean
@@ -108,8 +106,7 @@ export type FullTrack = Track & {
   user: FullUser
 }
 
-/** Suffixed with "model", these types come from the non-v1 API routes **/
-
+// Suffixed with "model", these types come from the non-v1 API routes
 export type RemixParentModel = {
   has_remix_author_reposted: boolean
   has_remix_author_saved: boolean

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -10,42 +10,102 @@ export type CoverPhoto = {
 }
 
 export type User = {
-    album_count: number
-    bio: string
-    cover_photo: CoverPhoto
-    followee_count: number
-    follower_count: number
-    handle: string
-    id: string
-    is_verified: boolean
-    location: string
-    name: string
-    playlist_count: number
-    profile_picture: ProfilePicture
-    repost_count: number
-    track_count: number
-    is_deactivated: boolean
+  album_count: number
+  bio: string
+  cover_photo: CoverPhoto | null
+  followee_count: number
+  follower_count: number
+  handle: string
+  id: string
+  is_deactivated: boolean
+  is_verified: boolean
+  location: string
+  name: string
+  playlist_count: number
+  profile_picture: ProfilePicture | null
+  repost_count: number
+  track_count: number
 }
 
 export type FullUser = User & {
-  balance: string
-  associated_wallets_balance: string
-  total_balance: string
   associated_sol_wallets_balance: string
+  associated_wallets_balance: string
+  balance: string
   blocknumber: number
-  wallet: string
+  cover_photo_legacy: string | null
+  cover_photo_sizes: string
   created_at: string
   creator_node_endpoint: string
   current_user_followee_follow_count: number
   does_current_user_follow: boolean
   handle_lc: string
-  is_creator: boolean
-  updated_at: string
-  cover_photo_sizes: string
-  cover_photo_legacy: string
-  profile_picture_sizes: string
-  profile_picture_legacy: string
-  metadata_multihash: string
   has_collectibles: boolean
-  playlist_library: any
+  is_creator: boolean
+  metadata_multihash: string
+  playlist_library: PlaylistLibrary
+  profile_picture_legacy: string | null
+  profile_picture_sizes: string
+  total_balance: string
+  updated_at: string
+  wallet: string
+}
+
+export type UserModel = {
+  bio: string
+  blockhash: string
+  blocknumber: number
+  cover_photo_sizes: string
+  cover_photo: null
+  created_at: string
+  creator_node_endpoint: string
+  handle_lc: string
+  handle: string
+  has_collectibles: boolean
+  is_creator: boolean
+  is_current: boolean
+  is_deactivated: boolean
+  is_verified: boolean
+  location: string
+  metadata_multihash: string
+  name: string
+  playlist_library: PlaylistLibrary
+  primary_id: number
+  profile_picture_sizes: string
+  profile_picture: null
+  replica_set_update_signer: string
+  secondary_ids: number[]
+  txhash: string
+  updated_at: string
+  user_id: number
+  wallet: string
+} & ComputedUserProps
+
+type ComputedUserProps = {
+  /** Aggregate User **/
+  album_count: number
+  followee_count: number
+  follower_count: number
+  playlist_count: number
+  repost_count: number
+  track_blocknumber: number
+  track_count: number
+  track_save_count: number
+  user_balance: string,
+
+  /** Current User **/
+  current_user_followee_follow_count: number
+  does_current_user_follow: boolean
+
+  /** Wallets **/
+  associated_sol_wallets_balance: string
+  associated_wallets_balance: string
+  balance: string
+  total_balance: string
+}
+
+export type PlaylistLibrary = {
+  contents: Array<{
+    playlist_id: number
+    type: string
+  }>
 }

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,52 @@
+export type ProfilePicture = {
+  ["150x150"]: string
+  ["480x480"]: string
+  ["1000x1000"]: string
+}
+
+
+export type CoverPhoto = {
+  ["640x"]: string
+  ["2000x"]: string
+}
+
+export type User = {
+    album_count: number
+    bio: string
+    cover_photo: CoverPhoto
+    followee_count: number
+    follower_count: number
+    handle: string
+    id: string
+    is_verified: boolean
+    location: string
+    name: string
+    playlist_count: number
+    profile_picture: ProfilePicture
+    repost_count: number
+    track_count: number
+    is_deactivated: boolean
+}
+
+export type FullUser = User & {
+  balance: string
+  associated_wallets_balance: string
+  total_balance: string
+  associated_sol_wallets_balance: string
+  blocknumber: number
+  wallet: string
+  created_at: string
+  creator_node_endpoint: string
+  current_user_followee_follow_count: number
+  does_current_user_follow: boolean
+  handle_lc: string
+  is_creator: boolean
+  updated_at: string
+  cover_photo_sizes: string
+  cover_photo_legacy: string
+  profile_picture_sizes: string
+  profile_picture_legacy: string
+  metadata_multihash: string
+  has_collectibles: boolean
+  playlist_library: any
+}

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,13 +1,12 @@
 export type ProfilePicture = {
-  ["150x150"]: string
-  ["480x480"]: string
-  ["1000x1000"]: string
+  ['150x150']: string
+  ['480x480']: string
+  ['1000x1000']: string
 }
 
-
 export type CoverPhoto = {
-  ["640x"]: string
-  ["2000x"]: string
+  ['640x']: string
+  ['2000x']: string
 }
 
 export type User = {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,3 +1,5 @@
+
+// The general case models come from the "/v1" routes
 export type ProfilePicture = {
   ['150x150']: string
   ['480x480']: string
@@ -27,6 +29,7 @@ export type User = {
   track_count: number
 }
 
+// Prefixed with "full", these models come from the "v1/full" route
 export type FullUser = User & {
   associated_sol_wallets_balance: string
   associated_wallets_balance: string
@@ -50,6 +53,7 @@ export type FullUser = User & {
   wallet: string
 }
 
+// Suffixed with "model", these types come from the non-v1 API routes
 export type UserModel = {
   bio: string
   blockhash: string
@@ -81,7 +85,7 @@ export type UserModel = {
 } & ComputedUserProps
 
 type ComputedUserProps = {
-  /** Aggregate User **/
+  // Aggregate User
   album_count: number
   followee_count: number
   follower_count: number
@@ -92,11 +96,11 @@ type ComputedUserProps = {
   track_save_count: number
   user_balance: string,
 
-  /** Current User **/
+  // Current User
   current_user_followee_follow_count: number
   does_current_user_follow: boolean
 
-  /** Wallets **/
+  // Wallets
   associated_sol_wallets_balance: string
   associated_wallets_balance: string
   balance: string


### PR DESCRIPTION
Also:
- Don't show deleted tracks in collections embed player
- Add a bit of typing:
  - `Track` (for `/v1/tracks` API), `FullTrack` for `v1/full/tracks` API, and `TrackModel` (for `/tracks` API)
  - `User`, `FullUser`, and `UserModel` (respecting the same naming convention above)