### PR TITLE
Add ?all=true to ignore health

### DIFF
--- a/src/servlets/api/index.ts
+++ b/src/servlets/api/index.ts
@@ -21,10 +21,16 @@ type Node = {
 
 export const router = express.Router()
 
+let allDiscoveryProviders: Node[] = []
+let allContentNodes: Node[] = []
 let usableDiscoveryProviders: Node[] = []
 let usableContentNodes: Node[] = []
 
 const updateDiscoveryProviders = async () => {
+  // Get all services (no healthy check)
+  const allDiscoveryProviders = await libs.ServiceProvider.listDiscoveryProviders()
+
+  // Get healthy services
   const registeredVersion = await libs.ethContracts.getCurrentVersion('discovery-node')
   console.info(LOG_PREFIX, `Registered version ${registeredVersion}`)
   let services = await libs.discoveryProvider.serviceSelector.findAll({ verbose: true })
@@ -32,23 +38,15 @@ const updateDiscoveryProviders = async () => {
   services = services
     .filter((service: { version: string }) => semver.gte(service.version, registeredVersion))
     .filter((service: { block_difference: number }) => service.block_difference <= MIN_BLOCK_DIFFERENCE)
-  console.info(LOG_PREFIX, `Updating internal discovery node hosts ${JSON.stringify(services)}`)
+
   // If we only have found MIN_HEALTHY_SERVICES, just show everything instead
+  console.info(LOG_PREFIX, `Updating internal discovery node hosts ${JSON.stringify(services)}`)
   if (services.length > MIN_HEALTHY_SERVICES) {
     console.info(LOG_PREFIX, `Enough services found ${services.length} > ${MIN_HEALTHY_SERVICES}`)
-    usableDiscoveryProviders = services.map((s: Node) => ({
-      owner: s.owner,
-      endpoint: s.endpoint,
-      spID: s.spID,
-      type: s.type,
-      blockNumber: s.blockNumber,
-      delegateOwnerWallet: s.delegateOwnerWallet
-    }))
+    usableDiscoveryProviders = services
   } else {
     console.info(LOG_PREFIX, `Not enough healthy services found, returning everything`)
-    // Get all services (no healthy check)
-    const allServices = await libs.ServiceProvider.listDiscoveryProviders()
-    usableDiscoveryProviders = allServices
+    usableDiscoveryProviders = allDiscoveryProviders
   }
 }
 
@@ -56,6 +54,7 @@ const updateContentNodes = async () => {
   const registeredVersion = await libs.ethContracts.getCurrentVersion('content-node')
   console.info(LOG_PREFIX, `Registered version ${registeredVersion}`)
   const services = await libs.ServiceProvider.listCreatorNodes()
+  allContentNodes = services
   usableContentNodes = services
 }
 
@@ -72,7 +71,8 @@ onStartup(() => {
  * Gets a randomized list of discovery node endpoints
  */
 router.get('/', async (req: express.Request, res: express.Response) => {
-  const randomizedEndpoints = shuffle(usableDiscoveryProviders.map((s) => s.endpoint))
+  const services = req.query.all ? allDiscoveryProviders : usableDiscoveryProviders
+  const randomizedEndpoints = shuffle(services.map((s) => s.endpoint))
   return res.json({ data: randomizedEndpoints })
 })
 
@@ -80,7 +80,8 @@ router.get('/', async (req: express.Request, res: express.Response) => {
  * Gets a randomized list of discovery node endpoints
  */
 router.get('/discovery', async (req: express.Request, res: express.Response) => {
-  const randomizedEndpoints = shuffle(usableDiscoveryProviders.map((s) => s.endpoint))
+  const services = req.query.all ? allDiscoveryProviders : usableDiscoveryProviders
+  const randomizedEndpoints = shuffle(services.map((s) => s.endpoint))
   return res.json({ data: randomizedEndpoints })
 })
 
@@ -88,15 +89,17 @@ router.get('/discovery', async (req: express.Request, res: express.Response) => 
  * Gets a randomized list of discovery node endpoints with verbose data
  */
 router.get('/discovery/verbose', async (req: express.Request, res: express.Response) => {
-  const randomizedEndpoints = shuffle(usableDiscoveryProviders)
-  return res.json({ data: randomizedEndpoints })
+  const services = req.query.all ? allDiscoveryProviders : usableDiscoveryProviders
+  const randomizedServices = shuffle(services)
+  return res.json({ data: randomizedServices })
 })
 
 /**
  * Gets a randomized list of content node endpoints
  */
 router.get('/content', async (req: express.Request, res: express.Response) => {
-  const randomizedEndpoints = shuffle(usableContentNodes.map((s) => s.endpoint))
+  const services = req.query.all ? allContentNodes : usableContentNodes
+  const randomizedEndpoints = shuffle(services.map((s) => s.endpoint))
   return res.json({ data: randomizedEndpoints })
 })
 
@@ -104,6 +107,7 @@ router.get('/content', async (req: express.Request, res: express.Response) => {
  * Gets a randomized list of content node endpoints with verbose data
  */
 router.get('/content/verbose', async (req: express.Request, res: express.Response) => {
-  const randomizedEndpoints = shuffle(usableContentNodes)
-  return res.json({ data: randomizedEndpoints })
+  const services = req.query.all ? allContentNodes : usableContentNodes
+  const randomizedServices = shuffle(services)
+  return res.json({ data: randomizedServices })
 })


### PR DESCRIPTION
Adds `all` query param so Content Nodes can ignore health and just fetch all nodes in order to resolve an issue that is occasionally causing a page:

> a CN didnt have dn3 in its list of signers, prob bc dn3 was restarting / momentarily down when the CN pulled its list of signers from [api.audius.co](http://api.audius.co/). dn3 was attempting to stream via this CN's /tracks/cidstream route which requires a signature from a registered signer, causing errors until dn3 selected a diff content node to stream from

Tested by manually setting `MIN_HEALTHY_SERVICES` to `1` and running `npm i && npm run start`. Then on stage dn2: `docker stop server`. After about a minute, localhost:8000/api and localhost:8000/discovery/verbose didn't show the offline node, while the same routes with `?all=true` did.