### PR TITLE
Update protocol dashboard build path

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -12,7 +12,7 @@ PUBLIC_URL=https://audius.co
 OPENSEA_ENDPOINT=https://collectibles.audius.co/api/v1
 SOLANA_RPC_ENDPOINT=https://audius.rpcpool.com
 
-PROTOCOL_DASHBOARD_BUILD_URL=https://d2wytf24n0i6o4.cloudfront.net/build.zip
+PROTOCOL_DASHBOARD_BUILD_URL=https://d2wytf24n0i6o4.cloudfront.net/dist.zip
 AUDIUS_SITE_BUILD_URL=https://audius-site-ipfs.s3-us-west-1.amazonaws.com/build-ipfs-production.zip
 IPFS_PROTOCOL=http
 IPFS_HOST=ipfs

--- a/.env.stage
+++ b/.env.stage
@@ -12,7 +12,7 @@ PUBLIC_URL=https://staging.audius.co
 OPENSEA_ENDPOINT=https://collectibles.audius.co/api/v1
 SOLANA_RPC_ENDPOINT=https://audius.rpcpool.com
 
-PROTOCOL_DASHBOARD_BUILD_URL=https://d12y891c1d17lv.cloudfront.net/build.zip
+PROTOCOL_DASHBOARD_BUILD_URL=https://d12y891c1d17lv.cloudfront.net/dist.zip
 AUDIUS_SITE_BUILD_URL=https://audius-site-ipfs.s3-us-west-1.amazonaws.com/build-ipfs-staging.zip
 IPFS_PROTOCOL=http
 IPFS_HOST=ipfs


### PR DESCRIPTION
Updates the protocol dashboard zip file to be dist.zip instead of build.zip since we changed the output path when switching from CRA to Vite. I tested the flow e2e (protocol dashboard build -> GA /ipfs/update_build -> GA /ipfs/pin_build) to confirm that the correct files are built, unzipped, and accessible via IPFS.

<img width="1412" alt="Screenshot 2023-10-06 at 1 40 52 PM" src="https://github.com/AudiusProject/general-admission/assets/4657956/e9a57e9c-96ec-4caa-8411-e1fc32fb8573">
