### PR TITLE
[C-3491] Fix simple proxy, pipe headers through

### DIFF
--- a/src/servlets/proxy/index.ts
+++ b/src/servlets/proxy/index.ts
@@ -82,19 +82,6 @@ router.get(
   '/simple',
   async (req: express.Request, expressRes: express.Response) => {
     const url = req.query.url as string
-    const result = await new Promise((resolve, reject) => {
-      request({
-        url,
-        headers: {
-          'Access-Control-Allow-Method': '*',
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Headers': '*',
-        },
-      }).then(
-        (res) => resolve(res),
-        (error) => reject(error)
-      )
-    })
-    expressRes.send(result)
+    request.get(url).pipe(expressRes)
   }
-)
+);

--- a/src/servlets/proxy/index.ts
+++ b/src/servlets/proxy/index.ts
@@ -84,4 +84,4 @@ router.get(
     const url = req.query.url as string
     request.get(url).pipe(expressRes)
   }
-);
+)


### PR DESCRIPTION
Instagram sign ups on web were missing profile pic because the `/simple` ga proxy was not sending the correct content-type header.

Use `pipe` instead to pass the response and headers along.

Tested that this avoids CORS errors on web + mobile. **Only tested IG sign up flow, if there are other usages of the `/simple` proxy please advise**