### PR TITLE
Add mem_limit to mitigate mem leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd general-admission
 
 cp .env.stage .env # or .env.prod
 
-docker-compose up --build
+docker compose up --build -d
 ```
 
 visit http://localhost:9000.
@@ -30,7 +30,7 @@ visit http://localhost:9000.
 and to stop it:
 
 ```
-docker-compose down
+docker compose down
 ```
 
 or if you want to run just the node service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: node
+    mem_limit: 3g
     restart: unless-stopped
     volumes:
       # Mount the code for hot reloading


### PR DESCRIPTION
Add a mem_limit cuz this container has a mem leak. Unclear from what but mitigating for now so it can restart automatically without taking down the whole server.

Use `docker compose` not `docker-compose` because it supports mem_limit.

Tested on stage, mem_limit is properly set.

```
CONTAINER ID   NAME      CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
a3fd7db378d0   nginx     0.00%     6.539MiB / 3.839GiB   0.17%     7.54kB / 2.26kB   2.78MB / 8.19kB   3
efe1f952971d   node      0.00%     163.5MiB / 3GiB       5.32%     481kB / 271kB     4.1kB / 8.19kB    31
8ac44a41789b   social    0.00%     84.04MiB / 3.839GiB   2.14%     2.51kB / 0B       79.5MB / 4.1kB    29
```