### PR TITLE
Add special routes to prevent user handle conflicts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import './fetch-polyfill'
 import { startup } from './onStartup'
 import { MetaTagFormat } from './servlets/metaTags/types'
+import { APP_ROUTES } from './servlets/utils/constants'
 
 import getMetaTagsResponse from './servlets/metaTags'
 import { router as proxyRouter } from './servlets/proxy'
@@ -65,6 +66,10 @@ router.get('/audio', (req: express.Request, res: express.Response) => {
   getMetaTagsResponse(MetaTagFormat.AUDIO, req, res)
 })
 
+router.get('/rewards', (req: express.Request, res: express.Response) => {
+  getMetaTagsResponse(MetaTagFormat.AUDIO, req, res)
+})
+
 router.get(
   [
     '/:handle',
@@ -75,7 +80,14 @@ router.get(
   ],
   (req: express.Request, res: express.Response) => {
     const { handle } = req.params
-    if (handle.trim() === 'download') {
+    const trimmedHandle = handle.trim()
+
+    // Check if this is an app route that should not be treated as a user handle
+    if (APP_ROUTES.includes(trimmedHandle)) {
+      return getMetaTagsResponse(MetaTagFormat.Default, req, res)
+    }
+
+    if (trimmedHandle === 'download') {
       return getMetaTagsResponse(MetaTagFormat.DownloadApp, req, res)
     }
     getMetaTagsResponse(MetaTagFormat.User, req, res)
@@ -83,27 +95,59 @@ router.get(
 )
 
 router.get(
-  ['/:handle/collectibles/:collectibleId'],
+  ['/:handle/collectibles'],
   (req: express.Request, res: express.Response) => {
-    getMetaTagsResponse(MetaTagFormat.Collectible, req, res)
+    const { handle } = req.params
+    const trimmedHandle = handle.trim()
+
+    // Check if this is an app route that should not be treated as a user handle
+    if (APP_ROUTES.includes(trimmedHandle)) {
+      return getMetaTagsResponse(MetaTagFormat.Default, req, res)
+    }
+
+    getMetaTagsResponse(MetaTagFormat.Collectibles, req, res)
   }
 )
 
 router.get(
-  ['/:handle/collectibles', '/:handle/audio-nft-playlist'],
+  ['/:handle/collectibles/:collectibleId'],
   (req: express.Request, res: express.Response) => {
-    getMetaTagsResponse(MetaTagFormat.Collectibles, req, res)
+    const { handle } = req.params
+    const trimmedHandle = handle.trim()
+
+    // Check if this is an app route that should not be treated as a user handle
+    if (APP_ROUTES.includes(trimmedHandle)) {
+      return getMetaTagsResponse(MetaTagFormat.Default, req, res)
+    }
+
+    getMetaTagsResponse(MetaTagFormat.Collectible, req, res)
   }
 )
 
 router.get(
   '/:handle/:title/remixes',
   (req: express.Request, res: express.Response) => {
+    const { handle } = req.params
+    const trimmedHandle = handle.trim()
+
+    // Check if this is an app route that should not be treated as a user handle
+    if (APP_ROUTES.includes(trimmedHandle)) {
+      return getMetaTagsResponse(MetaTagFormat.Default, req, res)
+    }
+
     getMetaTagsResponse(MetaTagFormat.Remixes, req, res)
   }
 )
 
 router.get('/:handle/:title', (req: express.Request, res: express.Response) => {
+  const { handle } = req.params
+  const trimmedHandle = handle.trim()
+
+  // Check if this is an app route that should not be treated as a user handle
+  if (APP_ROUTES.includes(trimmedHandle)) {
+    return getMetaTagsResponse(MetaTagFormat.Default, req, res)
+  }
+
   getMetaTagsResponse(
     req.query.commentId ? MetaTagFormat.Comment : MetaTagFormat.Track,
     req,
@@ -114,6 +158,14 @@ router.get('/:handle/:title', (req: express.Request, res: express.Response) => {
 router.get(
   ['/:handle/album/:title', '/:handle/playlist/:title'],
   (req: express.Request, res: express.Response) => {
+    const { handle } = req.params
+    const trimmedHandle = handle.trim()
+
+    // Check if this is an app route that should not be treated as a user handle
+    if (APP_ROUTES.includes(trimmedHandle)) {
+      return getMetaTagsResponse(MetaTagFormat.Default, req, res)
+    }
+
     getMetaTagsResponse(MetaTagFormat.Collection, req, res)
   }
 )

--- a/src/servlets/utils/constants.ts
+++ b/src/servlets/utils/constants.ts
@@ -1,124 +1,86 @@
 export const DEFAULT_IMAGE_URL =
-  'https://download.audius.co/static-resources/preview-image.jpg'
+  "https://download.audius.co/static-resources/preview-image.jpg";
 export const AUDIO_REWARDS_IMAGE_URL =
-  'https://download.audius.co/static-resources/audio-rewards.png'
-export const HEAVY_ROTATION_URL =
-  'https://download.audius.co/static-resources/heavy-rotation.png'
-export const LET_THEM_DJ_URL =
-  'https://download.audius.co/static-resources/let-them-dj.png'
-export const BEST_NEW_RELEASES_URL =
-  'https://download.audius.co/static-resources/best-new-releases.png'
-export const UNDER_THE_RADAR_URL =
-  'https://download.audius.co/static-resources/under-the-radar.png'
-export const TOP_ALBUMS_URL =
-  'https://download.audius.co/static-resources/top-albums.png'
-export const TOP_PLAYLISTS_URL =
-  'https://download.audius.co/static-resources/top-playlists.png'
-export const MOST_LOVED_URL =
-  'https://download.audius.co/static-resources/most-loved.png'
-export const FEELING_LUCKY_URL =
-  'https://download.audius.co/static-resources/feeling-lucky.png'
-export const REMIXABLES =
-  'https://download.audius.co/static-resources/remixables.jpeg'
-export const UNDERGROUND_TRENDING =
-  'https://download.audius.co/static-resources/underground-trending.png'
-export const PREMIUM_TRACKS =
-  'https://download.audius.co/static-resources/premium-tracks.png'
+  "https://download.audius.co/static-resources/audio-rewards.png";
 export const SIGNUP_REF_IMAGE_URL =
-  'https://download.audius.co/static-resources/signup_referral.png'
-export const USER_NODE_IPFS_GATEWAY = 'https://usermetadata.audius.co/ipfs/'
+  "https://download.audius.co/static-resources/signup_referral.png";
+export const USER_NODE_IPFS_GATEWAY = "https://usermetadata.audius.co/ipfs/";
 
 // App routes that should not be treated as user handles
 export const APP_ROUTES = [
-  'download',
-  'upload',
-  'explore',
-  'trending',
-  'check',
-  'undefined',
-  'press',
-  'audio',
-  'signup',
-  'error',
-  'health_check',
-  'proxy',
-  'social',
-  'apple-app-site-association',
-  '204',
-] as readonly string[]
-
-export interface ExploreInfoType {
-  title: string
-  description: string
-  image: string
-}
-
-export const exploreMap: { [key: string]: ExploreInfoType } = {
-  'heavy-rotation': {
-    title: 'Heavy Rotation',
-    description: 'Your top tracks, in one place',
-    image: HEAVY_ROTATION_URL,
-  },
-  'let-them-dj': {
-    title: 'Let Them DJ',
-    description: 'Playlists created by the people you follow',
-    image: LET_THEM_DJ_URL,
-  },
-  'best-new-releases': {
-    title: 'Best New Releases',
-    description: 'From the artists you follow',
-    image: BEST_NEW_RELEASES_URL,
-  },
-  'under-the-radar': {
-    title: 'Under The Radar',
-    description: 'Tracks you might have missed from the artists you follow',
-    image: UNDER_THE_RADAR_URL,
-  },
-  'top-albums': {
-    title: 'Top Albums',
-    description: 'The top albums from all of Audius',
-    image: TOP_ALBUMS_URL,
-  },
-  'top-playlists': {
-    title: 'Top Playlists',
-    description: 'The top playlists on Audius right now',
-    image: TOP_PLAYLISTS_URL,
-  },
-  'trending-playlists': {
-    title: 'Trending Playlists',
-    description: 'The trending playlists on Audius right now',
-    image: TOP_PLAYLISTS_URL,
-  },
-  'playlists': {
-    title: 'Trending Playlists',
-    description: 'The trending playlists on Audius right now',
-    image: TOP_PLAYLISTS_URL,
-  },
-  'underground': {
-    title: 'Underground Trending',
-    description:
-      'Some of the best up-and-coming music on Audius all in one place',
-    image: UNDERGROUND_TRENDING,
-  },
-  'most-loved': {
-    title: 'Most Loved',
-    description: 'Tracks favorited by the people you follow',
-    image: MOST_LOVED_URL,
-  },
-  'feeling-lucky': {
-    title: 'Feeling Lucky',
-    description: 'A purely random collection of tracks from Audius',
-    image: FEELING_LUCKY_URL,
-  },
-  'remixables': {
-    title: 'Remixables',
-    description:
-      'Popular tracks with remixes & stems you can use in your own tracks',
-    image: REMIXABLES,
-  },
-  'premium-tracks': {
-    title: 'Premium Tracks',
-    description: 'Explore premium music available to purchase.',
-    image: PREMIUM_TRACKS,
-  },
-}
+  "download",
+  "upload",
+  "explore",
+  "trending",
+  "check",
+  "undefined",
+  "press",
+  "audio",
+  "signup",
+  "error",
+  "health_check",
+  "proxy",
+  "social",
+  "apple-app-site-association",
+  "204",
+  "feed",
+  "favorites",
+  "library",
+  "history",
+  "dashboard",
+  "rewards",
+  "airdrop",
+  "wallet",
+  "settings",
+  "signin",
+  "login",
+  "join",
+  "signon",
+  "register",
+  "oauth",
+  "notifications",
+  "app-redirect",
+  "deactivate",
+  "messages",
+  "payments",
+  "dev-tools",
+  "search",
+  "404",
+  "empty_page",
+  "genres",
+  "legal",
+  "auth-redirect",
+  "reposting_users",
+  "favoriting_users",
+  "following",
+  "followers",
+  "supporting",
+  "top-supporters",
+  "account",
+  "verification",
+  "about",
+  "change-email",
+  "change-password",
+  "authorized-apps",
+  "label-account",
+  "managing-you",
+  "accounts-you-manage",
+  "export-private-key",
+  "transaction-history",
+  "coins",
+  "solana",
+  "user-id-parser",
+  "coin-api-mocks",
+  "create-email",
+  "create-password",
+  "create-login-details",
+  "pick-handle",
+  "review-handle",
+  "finish-profile",
+  "select-genres",
+  "select-artists",
+  "loading",
+  "app-cta",
+  "completed",
+  "completed-referrer",
+] as readonly string[];

--- a/src/servlets/utils/constants.ts
+++ b/src/servlets/utils/constants.ts
@@ -28,6 +28,25 @@ export const SIGNUP_REF_IMAGE_URL =
   'https://download.audius.co/static-resources/signup_referral.png'
 export const USER_NODE_IPFS_GATEWAY = 'https://usermetadata.audius.co/ipfs/'
 
+// App routes that should not be treated as user handles
+export const APP_ROUTES = [
+  'download',
+  'upload',
+  'explore',
+  'trending',
+  'check',
+  'undefined',
+  'press',
+  'audio',
+  'signup',
+  'error',
+  'health_check',
+  'proxy',
+  'social',
+  'apple-app-site-association',
+  '204',
+] as readonly string[]
+
 export interface ExploreInfoType {
   title: string
   description: string
@@ -100,6 +119,6 @@ export const exploreMap: { [key: string]: ExploreInfoType } = {
   'premium-tracks': {
     title: 'Premium Tracks',
     description: 'Explore premium music available to purchase.',
-    image: PREMIUM_TRACKS
-  }
+    image: PREMIUM_TRACKS,
+  },
 }

--- a/src/servlets/utils/helpers.ts
+++ b/src/servlets/utils/helpers.ts
@@ -1,11 +1,6 @@
 import { FullTrack, Track, TrackModel } from '../../types/Track'
 import { FullUser, UserModel } from '../../types/User'
-import {
-  DEFAULT_IMAGE_URL,
-  ExploreInfoType,
-  exploreMap,
-  USER_NODE_IPFS_GATEWAY,
-} from './constants'
+import { DEFAULT_IMAGE_URL, USER_NODE_IPFS_GATEWAY } from './constants'
 import { encodeHashId } from './hashids'
 
 const ENV = process.env
@@ -148,16 +143,13 @@ export const getUserByHandle = async (handle: string): Promise<UserModel> => {
   throw new Error(`Failed to get user ${handle}`)
 }
 
-export const getExploreInfo = (type: string): ExploreInfoType => {
-  if (!Object.keys(exploreMap).includes(type)) {
-    return {
-      title: 'Just For You',
-      description: `Content curated for you based on your likes, reposts, and follows.
+export const getExploreInfo = (type: string): any => {
+  return {
+    title: 'Just For You',
+    description: `Content curated for you based on your likes, reposts, and follows.
                     Refreshes often so if you like a track, favorite it.`,
-      image: DEFAULT_IMAGE_URL,
-    }
+    image: DEFAULT_IMAGE_URL,
   }
-  return exploreMap[type]
 }
 
 /**
@@ -166,8 +158,10 @@ export const getExploreInfo = (type: string): ExploreInfoType => {
  */
 export const shuffle = (a: any[]) => {
   for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1)) as number;
-    [a[i], a[j]] = [a[j], a[i]]
+    const j = Math.floor(Math.random() * (i + 1)) as number
+    const temp = a[i]
+    a[i] = a[j]
+    a[j] = temp
   }
   return a
 }


### PR DESCRIPTION
/rewards route was hitting a user with rewards handle which is supper bad. Added a bunch more special routes to GA to avoid this. I also updated /rewards to do the same thing as /audio.